### PR TITLE
Add UDID profile download and Pages workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.p12
+*.pem
+*.key
+*.mobileprovision
+.env

--- a/Account/SignIn.html
+++ b/Account/SignIn.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Sign In — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="../assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="../index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="../pricing.html">Pricing</a>
+      <a href="../CreateOrder/Standard.html">Order</a>
+      <a href="../team.html">Team</a>
+      <a href="../help.html">Help</a>
+      <a href="../share.html">Share</a>
+      <a href="../support.html">Support</a>
+      <a href="../Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="../Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -29,7 +29,7 @@
     <input class="input" required type="password" name="password"/>
     <div style="display:flex;gap:10px;margin-top:12px">
       <button class="btn" type="submit">Sign In</button>
-      <a class="btn secondary" href="/Account/SignUp.html">Create account</a>
+      <a class="btn secondary" href="../Account/SignUp.html">Create account</a>
     </div>
   </form>
 </div>
@@ -41,10 +41,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="../terms.html">Terms</a> · <a href="../privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="../assets/js/main.js"></script>
 
 </body></html>

--- a/Account/SignUp.html
+++ b/Account/SignUp.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Sign Up — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="../assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="../index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="../pricing.html">Pricing</a>
+      <a href="../CreateOrder/Standard.html">Order</a>
+      <a href="../team.html">Team</a>
+      <a href="../help.html">Help</a>
+      <a href="../share.html">Share</a>
+      <a href="../support.html">Support</a>
+      <a href="../Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="../Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -31,7 +31,7 @@
     <label><input type="checkbox" required/> I agree</label>
     <div style="display:flex;gap:10px;margin-top:12px">
       <button class="btn" type="submit">Sign Up</button>
-      <a class="btn secondary" href="/Account/SignIn.html">Sign in</a>
+      <a class="btn secondary" href="../Account/SignIn.html">Sign in</a>
     </div>
   </form>
 </div>
@@ -43,10 +43,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="../terms.html">Terms</a> · <a href="../privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="../assets/js/main.js"></script>
 
 </body></html>

--- a/CreateOrder/Custom.html
+++ b/CreateOrder/Custom.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Order — Custom Plan</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="../assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="../index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="../pricing.html">Pricing</a>
+      <a href="../CreateOrder/Standard.html">Order</a>
+      <a href="../team.html">Team</a>
+      <a href="../help.html">Help</a>
+      <a href="../share.html">Share</a>
+      <a href="../support.html">Support</a>
+      <a href="../Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="../Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -34,7 +34,7 @@
     <textarea class="input" name="notes" rows="4"></textarea>
     <div style="display:flex;gap:10px;margin-top:12px">
       <button class="btn" type="submit">Submit Request</button>
-      <a class="btn secondary" href="/pricing.html">Back</a>
+      <a class="btn secondary" href="../pricing.html">Back</a>
     </div>
   </form>
 </div>
@@ -46,10 +46,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="../terms.html">Terms</a> · <a href="../privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="../assets/js/main.js"></script>
 
 </body></html>

--- a/CreateOrder/Standard.html
+++ b/CreateOrder/Standard.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Order — Standard Plan</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="../assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="../index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="../pricing.html">Pricing</a>
+      <a href="../CreateOrder/Standard.html">Order</a>
+      <a href="../team.html">Team</a>
+      <a href="../help.html">Help</a>
+      <a href="../share.html">Share</a>
+      <a href="../support.html">Support</a>
+      <a href="../Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="../Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -32,7 +32,7 @@
     <textarea class="input" name="notes" rows="4" placeholder="Entitlements, bundle IDs, etc."></textarea>
     <div style="display:flex;gap:10px;margin-top:12px">
       <button class="btn" type="submit">Pay & Generate</button>
-      <a class="btn secondary" href="/pricing.html">Back</a>
+      <a class="btn secondary" href="../pricing.html">Back</a>
     </div>
   </form>
 </div>
@@ -44,10 +44,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="../terms.html">Terms</a> · <a href="../privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="../assets/js/main.js"></script>
 
 </body></html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # p12-site
+
+## Purpose
+This project hosts a static site for distributing iOS UDID profiles and certificate information.
+
+## Setup
+Clone the repository and serve the files with any static web server or via GitHub Pages.
+
+## Environment Notes
+Development requires only basic HTML/CSS; no build tools or backend services are needed.

--- a/help.html
+++ b/help.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Help — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="CreateOrder/Standard.html">Order</a>
+      <a href="team.html">Team</a>
+      <a href="help.html">Help</a>
+      <a href="share.html">Share</a>
+      <a href="support.html">Support</a>
+      <a href="Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -48,10 +48,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a> · <a href="privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="assets/js/main.js"></script>
 
 </body></html>

--- a/index.html
+++ b/index.html
@@ -4,22 +4,22 @@
 <head>
   <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>P12Hub — iOS P12 Certificates</title>
-  <link rel="stylesheet" href="/assets/css/style.css"/>
+  <link rel="stylesheet" href="assets/css/style.css"/>
 </head>
 <body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="CreateOrder/Standard.html">Order</a>
+      <a href="team.html">Team</a>
+      <a href="help.html">Help</a>
+      <a href="share.html">Share</a>
+      <a href="support.html">Support</a>
+      <a href="Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -28,8 +28,9 @@
   <h1 style="margin:0;font-size:2.2rem">Get iOS <span class="badge">.p12</span> Certificates & <span class="badge">.mobileprovision</span> fast</h1>
   <p class="muted">Clean, modern storefront inspired by popular P12 vendors — ready for your branding and payment links.</p>
   <div style="display:flex;gap:12px;margin-top:16px">
-    <a class="btn" href="/CreateOrder/Standard.html">Buy Now</a>
-    <a class="btn secondary" href="/pricing.html">See Pricing</a>
+    <a class="btn" href="CreateOrder/Standard.html">Buy Now</a>
+    <a class="btn secondary" href="pricing.html">See Pricing</a>
+    <a class="btn secondary" href="udid.mobileconfig" download>Get UDID</a>
   </div>
 </section>
 
@@ -38,18 +39,18 @@
     <h3>Standard Plan</h3>
     <p class="muted">P12 & MP file • 1 year validity • Sign unlimited IPAs</p>
     <h2 style="margin:8px 0 16px">$14</h2>
-    <a class="btn" href="/CreateOrder/Standard.html">Buy Standard</a>
+    <a class="btn" href="CreateOrder/Standard.html">Buy Standard</a>
   </div>
   <div class="card">
     <h3>Custom Plan</h3>
     <p class="muted">Custom entitlements & capabilities (GameCenter, Push, etc.)</p>
     <h2 style="margin:8px 0 16px">$??</h2>
-    <a class="btn" href="/CreateOrder/Custom.html">Request Custom</a>
+    <a class="btn" href="CreateOrder/Custom.html">Request Custom</a>
   </div>
   <div class="card">
     <h3>Status Check</h3>
     <p class="muted">Client-side mock to check P12/MP pair validity (placeholder).</p>
-    <a class="btn secondary" href="/help.html#checker">Open Checker</a>
+    <a class="btn secondary" href="help.html#checker">Open Checker</a>
   </div>
 </section>
 
@@ -72,11 +73,11 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a> · <a href="privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="assets/js/main.js"></script>
 
 </body>
 </html>

--- a/pricing.html
+++ b/pricing.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Pricing — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="CreateOrder/Standard.html">Order</a>
+      <a href="team.html">Team</a>
+      <a href="help.html">Help</a>
+      <a href="share.html">Share</a>
+      <a href="support.html">Support</a>
+      <a href="Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -23,8 +23,8 @@
 <div class="container">
   <h2>Pricing</h2>
   <div class="grid cards">
-    <div class="card"><h3>Standard Plan</h3><p>Includes P12 + mobileprovision, 1-year validity, unlimited signings.</p><h2>$14</h2><a class="btn" href="/CreateOrder/Standard.html">Buy</a></div>
-    <div class="card"><h3>Custom Plan</h3><p>For capabilities like Push, Sign in with Apple, Game Center, etc.</p><h2>Contact</h2><a class="btn" href="/CreateOrder/Custom.html">Request</a></div>
+    <div class="card"><h3>Standard Plan</h3><p>Includes P12 + mobileprovision, 1-year validity, unlimited signings.</p><h2>$14</h2><a class="btn" href="CreateOrder/Standard.html">Buy</a></div>
+    <div class="card"><h3>Custom Plan</h3><p>For capabilities like Push, Sign in with Apple, Game Center, etc.</p><h2>Contact</h2><a class="btn" href="CreateOrder/Custom.html">Request</a></div>
   </div>
   <div class="notice" style="margin-top:16px">Replace prices and add your own terms. This template does not sell anything by default.</div>
 </div>
@@ -36,10 +36,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a> · <a href="privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="assets/js/main.js"></script>
 
 </body></html>

--- a/privacy.html
+++ b/privacy.html
@@ -2,5 +2,5 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Privacy — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="assets/css/style.css"/></head><body>
 <div class="container"><h2>Privacy</h2><p class="muted">Add your privacy policy here.</p></div></body></html>

--- a/share.html
+++ b/share.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Share — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="CreateOrder/Standard.html">Order</a>
+      <a href="team.html">Team</a>
+      <a href="help.html">Help</a>
+      <a href="share.html">Share</a>
+      <a href="support.html">Support</a>
+      <a href="Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -37,10 +37,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a> · <a href="privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="assets/js/main.js"></script>
 
 </body></html>

--- a/success.html
+++ b/success.html
@@ -1,8 +1,11 @@
-
-<!doctype html><html lang="en"><head>
-<meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Support — P12Hub</title>
-<link rel="stylesheet" href="assets/css/style.css"/></head><body>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>UDID Installed — P12Hub</title>
+  <link rel="stylesheet" href="assets/css/style.css"/>
+</head>
+<body>
 
 <div class="nav">
   <div class="nav-inner container">
@@ -21,13 +24,8 @@
 </div>
 
 <div class="container">
-  <h2>Support</h2>
-  <p class="muted">Contact via Telegram/Email placeholders. Replace with your real handles.</p>
-  <div class="grid cards">
-    <div class="card"><h3>Telegram News</h3><a class="btn secondary">t.me/YourNews</a></div>
-    <div class="card"><h3>Telegram Support</h3><a class="btn secondary">t.me/YourSupport</a></div>
-    <div class="card"><h3>Email</h3><a class="btn secondary">support@your-domain</a></div>
-  </div>
+  <h2>Profile Installed</h2>
+  <p class="muted">Return to your browser to continue. You can close Settings.</p>
 </div>
 
 <div class="footer container">
@@ -42,5 +40,5 @@
   </div>
 </div>
 <script src="assets/js/main.js"></script>
-
-</body></html>
+</body>
+</html>

--- a/team.html
+++ b/team.html
@@ -2,20 +2,20 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Team — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="assets/css/style.css"/></head><body>
 
 <div class="nav">
   <div class="nav-inner container">
-    <a class="brand" href="/index.html"><span class="logo"></span><span>P12Hub</span></a>
+    <a class="brand" href="index.html"><span class="logo"></span><span>P12Hub</span></a>
     <nav class="nav-links">
-      <a href="/pricing.html">Pricing</a>
-      <a href="/CreateOrder/Standard.html">Order</a>
-      <a href="/team.html">Team</a>
-      <a href="/help.html">Help</a>
-      <a href="/share.html">Share</a>
-      <a href="/support.html">Support</a>
-      <a href="/Account/SignIn.html" class="btn ghost">Sign In</a>
-      <a href="/Account/SignUp.html" class="btn">Sign Up</a>
+      <a href="pricing.html">Pricing</a>
+      <a href="CreateOrder/Standard.html">Order</a>
+      <a href="team.html">Team</a>
+      <a href="help.html">Help</a>
+      <a href="share.html">Share</a>
+      <a href="support.html">Support</a>
+      <a href="Account/SignIn.html" class="btn ghost">Sign In</a>
+      <a href="Account/SignUp.html" class="btn">Sign Up</a>
     </nav>
   </div>
 </div>
@@ -36,10 +36,10 @@
       <div class="muted">Unofficial template for P12 certificate storefronts. Replace content with your own terms.</div>
     </div>
     <div>
-      <a href="/terms.html">Terms</a> · <a href="/privacy.html">Privacy</a>
+      <a href="terms.html">Terms</a> · <a href="privacy.html">Privacy</a>
     </div>
   </div>
 </div>
-<script src="/assets/js/main.js"></script>
+<script src="assets/js/main.js"></script>
 
 </body></html>

--- a/terms.html
+++ b/terms.html
@@ -2,5 +2,5 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Terms — P12Hub</title>
-<link rel="stylesheet" href="/assets/css/style.css"/></head><body>
+<link rel="stylesheet" href="assets/css/style.css"/></head><body>
 <div class="container"><h2>Terms</h2><p class="muted">Add your terms of service here.</p></div></body></html>

--- a/udid.mobileconfig
+++ b/udid.mobileconfig
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array/>
+  <key>PayloadOrganization</key>
+  <string>P12Hub</string>
+  <key>PayloadIdentifier</key>
+  <string>com.p12hub.udid</string>
+  <key>PayloadUUID</key>
+  <string>00000000-0000-0000-0000-000000000000</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+  <key>PayloadType</key>
+  <string>Profile Service</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- ignore certificate-related secrets and `.env`
- add UDID profile download link and success page with relative paths
- configure Dependabot and Pages deployment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a14aa4a34c832497ce4dbfb1fb8b6d