### PR TITLE
Add profile service configuration to UDID mobileconfig

### DIFF
--- a/udid.mobileconfig
+++ b/udid.mobileconfig
@@ -3,13 +3,24 @@
 <plist version="1.0">
 <dict>
   <key>PayloadContent</key>
-  <array/>
+  <dict>
+    <key>URL</key>
+    <string>https://example.com/udid</string>
+    <key>DeviceAttributes</key>
+    <array>
+      <string>UDID</string>
+    </array>
+  </dict>
   <key>PayloadOrganization</key>
   <string>P12Hub</string>
+  <key>PayloadDisplayName</key>
+  <string>P12Hub UDID Collection</string>
+  <key>PayloadDescription</key>
+  <string>Installs a profile to collect the device UDID.</string>
   <key>PayloadIdentifier</key>
   <string>com.p12hub.udid</string>
   <key>PayloadUUID</key>
-  <string>00000000-0000-0000-0000-000000000000</string>
+  <string>e47ba8fb-988c-428c-8bc9-4674b1b61044</string>
   <key>PayloadVersion</key>
   <integer>1</integer>
   <key>PayloadType</key>


### PR DESCRIPTION
## Summary
- Add service URL and device attribute list to the profile's `PayloadContent`.
- Include display name and description and supply a unique `PayloadUUID`.

## Testing
- `python - <<'PY'
import plistlib
with open('udid.mobileconfig','rb') as f:
    plistlib.load(f)
print('plist parsed successfully')
PY`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a161a443008324aca249fb23c2eb78