### PR TITLE
feat: hook sign-in and sign-up to auth API

### DIFF
--- a/Account/SignIn.html
+++ b/Account/SignIn.html
@@ -22,7 +22,7 @@
 
 <div class="container">
   <h2>Sign In</h2>
-  <form class="card" onsubmit="return fakeAuth(event)">
+  <form class="card" onsubmit="return signIn(event)">
     <label class="label">Email</label>
     <input class="input" required type="email" name="email"/>
     <label class="label">Password</label>

--- a/Account/SignUp.html
+++ b/Account/SignUp.html
@@ -22,7 +22,7 @@
 
 <div class="container">
   <h2>Create Account</h2>
-  <form class="card" onsubmit="return fakeAuth(event)">
+  <form class="card" onsubmit="return signUp(event)">
     <label class="label">Email</label>
     <input class="input" required type="email" name="email"/>
     <label class="label">Password</label>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,12 +1,7 @@
 
 function fakeCheckout(e){
   e.preventDefault();
-  alert('This is a static demo. Hook this to Stripe/PayPal later.'); 
-  return false;
-}
-function fakeAuth(e){
-  e.preventDefault();
-  alert('Auth is a placeholder in this static demo.'); 
+  alert('This is a static demo. Hook this to Stripe/PayPal later.');
   return false;
 }
 function fakeCheck(e){
@@ -15,3 +10,54 @@ function fakeCheck(e){
   out.textContent = 'Mock check: files look OK (demo). Replace with real API.';
   return false;
 }
+
+async function signIn(e){
+  e.preventDefault();
+  const form = e.target;
+  const email = form.email.value;
+  const password = form.password.value;
+  try {
+    // Use HTTPS to protect credentials in transit.
+    const res = await fetch('https://auth.example.com/signin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      alert('Sign in successful.');
+      // location.href = '../index.html';
+    } else {
+      const err = await res.json().catch(() => ({ message: 'Unknown error' }));
+      alert('Sign in failed: ' + err.message);
+    }
+  } catch (err) {
+    alert('Network error. Please try again.');
+  }
+  return false;
+}
+
+async function signUp(e){
+  e.preventDefault();
+  const form = e.target;
+  const email = form.email.value;
+  const password = form.password.value;
+  try {
+    // Server must validate inputs before creating an account.
+    const res = await fetch('https://auth.example.com/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      alert('Account created successfully.');
+      // location.href = '../index.html';
+    } else {
+      const err = await res.json().catch(() => ({ message: 'Unknown error' }));
+      alert('Sign up failed: ' + err.message);
+    }
+  } catch (err) {
+    alert('Network error. Please try again.');
+  }
+  return false;
+}
+


### PR DESCRIPTION
## Summary
- replace fake auth calls in sign-in/up forms with real API handlers
- implement signIn and signUp functions using secure HTTPS fetch requests and server response handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a167367118832490970457830da428