### PR TITLE
Document UDID API verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,14 @@ Clone the repository and serve the files with any static web server or via GitHu
 
 ## Environment Notes
 Development requires only basic HTML/CSS; no build tools or backend services are needed.
+
+## Verification
+To confirm the UDID API and profile template:
+
+1. `curl -i https://YOURAPP.vercel.app/api/udid`  
+   Expect a **200** response containing an `alive` message.
+
+2. `curl -i -X POST https://YOURAPP.vercel.app/api/udid --data-binary '<plist…>'`  
+   Expect a **200** response with `Content-Type: application/x-apple-aspen-config`.
+
+3. Open `assets/collector.mobileconfig` in a browser to confirm the configuration profile template.

--- a/api/udid/index.js
+++ b/api/udid/index.js
@@ -1,3 +1,13 @@
+/**
+ * Health check:
+ *   curl -i https://YOURAPP.vercel.app/api/udid
+ *     -> 200 with "alive"
+ * Submit profile:
+ *   curl -i -X POST https://YOURAPP.vercel.app/api/udid --data-binary '<plist…>'
+ *     -> 200 with Content-Type: application/x-apple-aspen-config
+ * Template:
+ *   Open assets/collector.mobileconfig in a browser to inspect the configuration profile.
+ */
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Content-Type', 'text/plain');


### PR DESCRIPTION
## Summary
- add README instructions to validate UDID API and profile template
- annotate UDID API handler with curl usage examples

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a173a44c848324b2637c8bffdaa04f