### PR TITLE
Fix UDID download path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
   <div style="display:flex;gap:12px;margin-top:16px">
     <a class="btn" href="CreateOrder/Standard.html">Buy Now</a>
     <a class="btn secondary" href="pricing.html">See Pricing</a>
-    <a href="/assets/collector.mobileconfig" download>Get UDID</a>
+    <a href="assets/collector.mobileconfig" download>Get UDID</a>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- use relative path for UDID mobileconfig so link works on GitHub Pages

## Testing
- `npm test` *(fails: package.json missing)*
- `curl -i https://p12-site.vercel.app/api/udid` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a18f001ff8832482a91b7edec49904